### PR TITLE
62 Adds IMU as input to cartographer and removed as input to ekf filter

### DIFF
--- a/vehicle_autonomy/propbot_gazebo/launch/propbot_playpen.launch
+++ b/vehicle_autonomy/propbot_gazebo/launch/propbot_playpen.launch
@@ -26,7 +26,7 @@ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSI
 <launch>
 
   <arg name="laser_enabled" default="true"/>
-  <arg name="kinect_enabled" default="true"/>
+  <arg name="kinect_enabled" default="false"/>
 
   <include file="$(find propbot_gazebo)/launch/playpen.launch" />
 

--- a/vehicle_autonomy/propbot_slam/config/propbot.lua
+++ b/vehicle_autonomy/propbot_slam/config/propbot.lua
@@ -48,7 +48,7 @@ TRAJECTORY_BUILDER_2D.num_accumulated_range_data = 1
 
 TRAJECTORY_BUILDER_2D.min_range = 0.3
 TRAJECTORY_BUILDER_2D.missing_data_ray_length = 2.
-TRAJECTORY_BUILDER_2D.use_imu_data = false
+TRAJECTORY_BUILDER_2D.use_imu_data = true
 TRAJECTORY_BUILDER_2D.ceres_scan_matcher.translation_weight = 10
 TRAJECTORY_BUILDER_2D.ceres_scan_matcher.rotation_weight = 15
 

--- a/vehicle_autonomy/propbot_state_estimation/config/odom_ekf_filter.yaml
+++ b/vehicle_autonomy/propbot_state_estimation/config/odom_ekf_filter.yaml
@@ -18,15 +18,4 @@ pose0_config: [true,  true,  true,
 pose0_differential: false
 pose0_relative: false
 
-imu0: /imu/data
-imu0_config: [false, false, false,
-              true, true, true,
-              false, false, false,
-              true, true, true,
-              false, false, false]
-imu0_differential: false
-imu0_queue_size: 10
-imu0_remove_gravitational_acceleration: true
-imu0_relative: false
-
 use_control: false


### PR DESCRIPTION
improves performance of mapping when robot makes large rotations

However, the changes made in this issue will not accurately simulate an IMU in the real world as the current simulated IMU measurements are generated by a ModelPlugin (the correct implementation is to use a SensorPlugin). This problem will be addressed in issue #132  

Closes #62 