### PR TITLE
Fix tf frequencies

### DIFF
--- a/vehicle_autonomy/propbot_slam/src/publish_slam_pose.cc
+++ b/vehicle_autonomy/propbot_slam/src/publish_slam_pose.cc
@@ -27,7 +27,7 @@ int main(int argc, char** argv) {
       node_handle.advertise<geometry_msgs::PoseWithCovarianceStamped>(
           "/slam/pose", 100);
 
-  ros::Rate loop_rate(1);
+  ros::Rate loop_rate(50);
 
   // Declare transform listener
   tf::TransformListener transform_listener;

--- a/vehicle_autonomy/propbot_state_estimation/config/map_ekf_filter.yaml
+++ b/vehicle_autonomy/propbot_state_estimation/config/map_ekf_filter.yaml
@@ -3,7 +3,7 @@ odom_frame: odom
 base_link_frame: base_link
 world_frame: map
 
-frequency: 30
+frequency: 50
 publish_tf: false
 print_diagnostics: true
 sensor_timeout: 0.1


### PR DESCRIPTION
This fixes the simulation. Before applying this fix my realtime rate in Gazebo is 0.3, this is NOT limited by the computer performance since my CPU usage was only at 25%. After applying the fix my realtime rate is steady at 1.0.
